### PR TITLE
Fix global installation with walk-up hook discovery

### DIFF
--- a/docs/GLOBAL_INSTALLATION.md
+++ b/docs/GLOBAL_INSTALLATION.md
@@ -1,0 +1,99 @@
+# Global Installation Guide
+
+Super Claude Kit supports both **project-local** and **global** installation modes.
+
+## Installation Modes
+
+### Project-Local (Default)
+```bash
+cd /path/to/your/project
+curl -fsSL https://raw.githubusercontent.com/arpitnath/super-claude-kit/master/install | bash
+```
+
+This installs Super Claude Kit into your project's `.claude/` directory. Each project has its own separate installation.
+
+### Global Installation
+```bash
+cd ~
+curl -fsSL https://raw.githubusercontent.com/arpitnath/super-claude-kit/master/install | bash
+```
+
+This installs Super Claude Kit into `~/.claude/` and works for **all projects** under your home directory.
+
+## How Global Installation Works
+
+### The Problem
+Claude Code automatically creates a `.claude/` directory in each project for its own settings (like `settings.local.json`). This caused issues with previous versions because the hook walk-up logic would stop at the first `.claude/` directory it found, even if it didn't contain any hooks.
+
+### The Solution
+The walk-up logic now searches for **specific hook files** rather than just the `.claude/` directory:
+
+```bash
+# OLD (broken): Stops at any .claude/ directory
+[ -d "$DIR/.claude" ] && cd "$DIR" && exec bash .claude/hooks/session-start.sh
+
+# NEW (fixed): Only stops when the hook FILE exists
+[ -f "$DIR/.claude/hooks/session-start.sh" ] && cd "$DIR" && exec bash .claude/hooks/session-start.sh
+```
+
+### Project Directory Tracking
+When launching from a subdirectory, Super Claude Kit:
+1. Captures the original project directory (`CLAUDE_PROJECT_DIR`)
+2. Saves it to `~/.claude/current_project_dir`
+3. Other hooks read from this file (handles cases where Claude Code changes `pwd` during session)
+
+## Example Directory Structure
+
+```
+/home/user/                          # Global installation here
+├── .claude/
+│   ├── hooks/                       # Super Claude Kit hooks
+│   │   ├── session-start.sh
+│   │   ├── pre-tool-use.sh
+│   │   └── ...
+│   ├── settings.local.json          # Hook configuration
+│   └── current_project_dir          # Saved project path
+│
+├── project-a/                       # Project A
+│   └── .claude/                     # Claude Code auto-created (empty)
+│       └── settings.local.json      # Project-specific settings
+│
+└── project-b/                       # Project B
+    └── src/
+```
+
+When you launch Claude Code from `/home/user/project-a/`:
+1. Walk-up searches for `session-start.sh`
+2. Finds it at `/home/user/.claude/hooks/session-start.sh`
+3. `CLAUDE_PROJECT_DIR` is set to `/home/user/project-a`
+4. Git operations use `-C "$PROJECT_DIR"` to work on the correct repo
+
+## Benefits of Global Installation
+
+- **Single installation** for all projects
+- **Consistent behavior** across all workspaces
+- **No duplication** of hooks and tools
+- **Easier updates** - update once, applies everywhere
+- **Works with any directory** - even non-git directories
+
+## Troubleshooting
+
+### Hooks not running
+Check that the hook files exist:
+```bash
+ls -la ~/.claude/hooks/session-start.sh
+```
+
+### Wrong project directory
+Check `current_project_dir`:
+```bash
+cat ~/.claude/current_project_dir
+```
+
+### Debug mode
+Enable debug logging:
+```bash
+export CLAUDE_DEBUG_HOOKS=true
+claude
+# Check: ~/.claude/session-start-debug.log
+```

--- a/install
+++ b/install
@@ -292,6 +292,8 @@ echo ""
 
 echo "Configuring Claude Code..."
 if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
+  # Generate settings with walk-up logic that finds hooks by FILE (not just .claude dir)
+  # This supports both project-local and global (~/.claude) installations
   cat > "$INSTALL_DIR/.claude/settings.local.json" << 'EOF'
 {
   "hooks": {
@@ -301,7 +303,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/session-start.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$PWD; DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/session-start.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/session-start.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -312,7 +314,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-task-analysis.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/pre-task-analysis.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/pre-task-analysis.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -323,7 +325,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/post-tool-use.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/post-tool-use.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/post-tool-use.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -334,7 +336,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-tool-use.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/pre-tool-use.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/pre-tool-use.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -345,7 +347,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/stop.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/stop.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/stop.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -356,7 +358,7 @@ if [ ! -f "$INSTALL_DIR/.claude/settings.local.json" ]; then
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/session-end.sh"
+            "command": "bash -c 'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ \"$DIR\" != \"/\" ]; do [ -f \"$DIR/.claude/hooks/session-end.sh\" ] && cd \"$DIR\" && exec bash .claude/hooks/session-end.sh; DIR=$(dirname \"$DIR\"); done'"
           }
         ]
       }
@@ -375,13 +377,20 @@ import sys
 with open('.claude/settings.local.json', 'r') as f:
     existing = json.load(f)
 
+# Walk-up logic for SessionStart: find hooks by looking for the specific hook FILE (not just .claude dir)
+# This fixes global installation where project dirs may have empty .claude/ from Claude Code
+def make_session_start_cmd(hook_file):
+    return f'bash -c \'export CLAUDE_PROJECT_DIR=$PWD; DIR=$PWD; while [ "$DIR" != "/" ]; do [ -f "$DIR/.claude/hooks/{hook_file}" ] && cd "$DIR" && exec bash .claude/hooks/{hook_file}; DIR=$(dirname "$DIR"); done\''
+
+# Other hooks read PROJECT_DIR from file saved by session-start.sh
+# This handles cases where Claude Code changes pwd during session
 def make_hook_cmd(hook_file):
-    return f'bash -c \'DIR=$PWD; while [ "$DIR" != "/" ]; do [ -d "$DIR/.claude" ] && cd "$DIR" && exec bash .claude/hooks/{hook_file}; DIR=$(dirname "$DIR"); done\''
+    return f'bash -c \'export CLAUDE_PROJECT_DIR=$(cat $HOME/.claude/current_project_dir 2>/dev/null || echo $PWD); DIR=$PWD; while [ "$DIR" != "/" ]; do [ -f "$DIR/.claude/hooks/{hook_file}" ] && cd "$DIR" && exec bash .claude/hooks/{hook_file}; DIR=$(dirname "$DIR"); done\''
 
 required_hooks = {
     "SessionStart": [{
         "matcher": "*",
-        "hooks": [{"type": "command", "command": make_hook_cmd("session-start.sh")}]
+        "hooks": [{"type": "command", "command": make_session_start_cmd("session-start.sh")}]
     }],
     "UserPromptSubmit": [{
         "matcher": "*",


### PR DESCRIPTION
## Problem

When Super Claude Kit is installed globally (e.g., `~/.claude/`), it doesn't work when launching Claude Code from subdirectories because:

1. **Claude Code creates project-level `.claude/` directories** automatically for storing `settings.local.json`
2. **Current walk-up logic stops at first `.claude/` found** - which may have no hooks!
3. **Scripts use relative paths** - after `cd` to hook parent, pwd is wrong for git operations

## Solution

### 1. Walk-up should find hooks, not just `.claude/` directory

```bash
# Before (broken)
[ -d "$DIR/.claude" ] && cd "$DIR" && exec bash .claude/hooks/session-start.sh

# After (fixed)
[ -f "$DIR/.claude/hooks/session-start.sh" ] && cd "$DIR" && exec bash .claude/hooks/session-start.sh
```

### 2. session-start.sh uses BASH_SOURCE for absolute paths

```bash
HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
```

### 3. Pass and persist project directory

```bash
export CLAUDE_PROJECT_DIR=$PWD
echo "$PROJECT_DIR" > "$CLAUDE_DIR/current_project_dir"
```

### 4. Git operations use -C flag

```bash
git -C "$PROJECT_DIR" rev-parse --git-dir
git -C "$PROJECT_DIR" branch --show-current
```

## Changes

- `hooks/session-start.sh`: Added global installation support with absolute paths
- `install`: Fixed walk-up logic to search for hook FILES instead of .claude directory
- `docs/GLOBAL_INSTALLATION.md`: Added documentation for global installation

## Benefits

- Single global installation works from any directory
- Project-level `.claude/` (auto-created by Claude Code) doesn't break hooks
- Git operations work on correct project
- Other hooks read saved PROJECT_DIR (handles pwd changes during session)