### PR TITLE
feat(dependency-scanner): add --exclude flag and expand default exclusions

### DIFF
--- a/tools/dependency-scanner/main.go
+++ b/tools/dependency-scanner/main.go
@@ -23,6 +23,7 @@ func print(args ...interface{}) {
 func main() {
 	pathFlag := flag.String("path", ".", "Path to scan for dependencies")
 	outputFlag := flag.String("output", "", "Output file path for graph (default: .claude/dep-graph.toon)")
+	excludeFlag := flag.String("exclude", "", "Comma-separated list of additional directories to exclude")
 	verboseFlag := flag.Bool("verbose", false, "Enable verbose output")
 	versionFlag := flag.Bool("version", false, "Show version information")
 
@@ -46,14 +47,28 @@ func main() {
 
 	startTime := time.Now()
 
+	// Parse exclusions
+	var excludeDirs []string
+	if *excludeFlag != "" {
+		for _, dir := range strings.Split(*excludeFlag, ",") {
+			dir = strings.TrimSpace(dir)
+			if dir != "" {
+				excludeDirs = append(excludeDirs, dir)
+			}
+		}
+	}
+
 	if *verboseFlag {
 		fmt.Printf("Starting dependency scan...\n")
 		fmt.Printf("Path: %s\n", *pathFlag)
 		fmt.Printf("Output: %s\n", outputPath)
+		if len(excludeDirs) > 0 {
+			fmt.Printf("Additional exclusions: %v\n", excludeDirs)
+		}
 		fmt.Println()
 	}
 
-	scanner, err := NewScanner(*pathFlag, *verboseFlag)
+	scanner, err := NewScanner(*pathFlag, *verboseFlag, excludeDirs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: Failed to create scanner: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Adds `--exclude` flag for comma-separated custom directory exclusions
- Significantly expands default exclusion list to skip common non-source directories

## Problem

The dependency scanner was taking ~25 seconds on projects with Python virtual environments because it scanned thousands of library files in `venv/site-packages/`. The hardcoded exclusion list only included 6 directories.

## Solution

**New `--exclude` flag:**
```bash
dependency-scanner --path . --exclude "custom1,custom2"
```

**Expanded default exclusions (35+ directories):**
- Python: `venv`, `.venv`, `virtualenv`, `site-packages`, `__pycache__`, `.pytest_cache`, `.mypy_cache`
- Build: `dist`, `build`, `.next`, `out`, `target`, `_build`, `.output`
- IDE: `.idea`, `.vscode`
- Data: `.data`, `.cache`, `cache`
- Coverage: `coverage`, `.coverage`, `htmlcov`
- VCS: `.git`, `.svn`, `.hg`
- Packages: `node_modules`, `vendor`, `bower_components`

## Results

On a real project with Python venvs:
- **Before:** 6538 files, 25 seconds
- **After:** 249 files, 2.3 seconds (~10x faster)

## Test plan

- [x] Built and tested locally
- [x] Verified `--exclude` flag works with custom directories
- [x] Confirmed session-start hook now completes in ~2.6s instead of ~26s