### PR TITLE
Add simple time based filtering for memory queries

### DIFF
--- a/tools/memory-graph/lib/query.py
+++ b/tools/memory-graph/lib/query.py
@@ -115,7 +115,7 @@ def parse_date_arg(value: str) -> Optional[datetime]:
     if value == "all" or value.strip() == "":
         return None
     # Parse time range
-    unit = value[-1]
+    unit = value[-1].lower()
     accepted_units = ["h", "d", "m", "y"]
     if unit not in accepted_units:
         raise ValueError(f"Time range unit must be one of: {accepted_units}.")


### PR DESCRIPTION
# Description
The goal of this PR is to allow for filtering node IDs by their updated date when querying data in the CLI. This functionality is offered through the `--since` argument.

# What does this PR fix?
This PR aims to address issue #22 

# Additional notes for reviewer
Some liberties have been taken with the time filtering, such as assuming a month is 30 days exactly.

This could be updated to be more agile (e.g., calculating n days in each month based on the current timestamp) given more time. For the time being, a simple implementation has been created.

# Example Usage
```
python3 query.py --command recent --since 24h
python3 query.py --command recent --since 1w
python3 query.py --command recent --since 5m
python3 query.py --command recent --since 1y
```